### PR TITLE
Reinstate `-Werror`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,9 +1,8 @@
 packages: gibbon-compiler
 
--- VS: commenting these out for now
---if (impl(ghc >= 9.8))
---    program-options
---        ghc-options: -Werror=x-no-partial
---else
---    program-options
---        ghc-options: -Werror
+if (impl(ghc >= 9.8))
+    program-options
+        ghc-options: -Werror=x-no-partial
+else
+    program-options
+        ghc-options: -Werror

--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,4 @@
 packages: gibbon-compiler
 
-if (impl(ghc >= 9.8))
-    program-options
-        ghc-options: -Werror=x-no-partial
-else
-    program-options
-        ghc-options: -Werror
+program-options
+    ghc-options: -Werror

--- a/gibbon-compiler/src/Gibbon/Common.hs
+++ b/gibbon-compiler/src/Gibbon/Common.hs
@@ -542,18 +542,18 @@ falsePrinted = "#f"
 unwrapLocVar :: LocVar -> Var
 unwrapLocVar locvar = case locvar of 
                             Single loc -> loc
-                            SoA dcon fieldLocs -> 
+                            SoA _dcon _fieldLocs ->
                                error $  "unwrapLocVar : Did not expect an SoA location! " ++ (show locvar)
                                 --dcon {- Bad, unsafe !! -}
 
 locsInLocVar :: LocVar -> [LocVar]
 locsInLocVar loc = case loc of 
-			Single _ -> [loc]
-			SoA dcon fieldLocs -> [(singleLocVar dcon)] ++ L.map (\(_, l) -> l) fieldLocs
+                        Single _ -> [loc]
+                        SoA dcon fieldLocs -> [(singleLocVar dcon)] ++ L.map (\(_, l) -> l) fieldLocs
 
 varsInLocVar :: LocVar -> [Var]
 varsInLocVar loc = case loc of 
-                        Single loc -> [loc]
+                        Single loc' -> [loc']
                         SoA dcon fieldLocs -> dcon : L.concatMap (varsInLocVar . snd) fieldLocs
 
 varsInRegVar :: RegVar -> [Var]
@@ -565,20 +565,20 @@ varsInRegVar reg = case reg of
 -- | Ideally we should not need this
 getDconLoc :: LocVar -> LocVar 
 getDconLoc loc = case loc of 
-                    SoA dcon fieldLocs -> Single dcon 
-                    Single lc -> loc 
+                    SoA dcon _fieldLocs -> Single dcon
+                    Single _lc -> loc
                             
 getFieldLoc :: (DataCon, FieldIndex) -> LocVar -> LocVar
 getFieldLoc (dcon, idx) loc = case loc of 
                                 SoA _ fieldLocs -> case Prelude.lookup (dcon, idx) fieldLocs of 
-                                                          Just loc -> loc
+                                                          Just loc' -> loc'
                                                           Nothing -> error "getFieldLoc : Field location not found!"
-                                Single lc -> error "getFieldLoc : Did not expect a non SoA location!"
+                                Single _sloc -> error "getFieldLoc : Did not expect a non SoA location!"
 
 getAllFieldLocsSoA :: LocVar -> [((DataCon, Int), LocVar)]
 getAllFieldLocsSoA loc = case loc of 
-                    SoA dcon fieldLocs -> fieldLocs
-                    Single lc -> error "getFieldLocs : Did not expect a non SoA location!"
+                    SoA _dcon fieldLocs -> fieldLocs
+                    Single _lc -> error "getFieldLocs : Did not expect a non SoA location!"
 
 freshSingleLocVar :: String -> PassM LocVar
 freshSingleLocVar m = do v <- gensym (toVar m)
@@ -600,7 +600,7 @@ freshSoALoc pfix lc = do
                      Single _ -> do 
                                   l' <- freshSingleLocVar (pfix ++"_loc")
                                   return l'
-                     SoA dbuf rst -> do 
+                     SoA _dbuf rst -> do
                                      dbuf' <- freshSingleLocVar (pfix ++ "_dloc")
                                      rst' <- freshFieldLocsSoA pfix rst
                                      let newSoALoc = SoA (unwrapLocVar dbuf') rst'
@@ -619,7 +619,7 @@ singleLocVar loc = Single loc
 
 appendNameToLocVar :: Var -> LocVar -> LocVar
 appendNameToLocVar v loc = case loc of 
-                            Single loc -> Single (v `varAppend` loc)
+                            Single sloc -> Single (v `varAppend` sloc)
                             SoA dcon fieldLocs -> SoA (v `varAppend` dcon) fieldLocs
 
 getLocVarFromFreeVarsTy :: FreeVarsTy -> LocVar
@@ -645,13 +645,13 @@ fromRegVarToFreeVarsTy reg = R reg
 
 getDataConRegFromRegVar :: RegVar -> RegVar
 getDataConRegFromRegVar reg = case reg of 
-                            SingleR v -> error "Common.hs: getDataConRegFromRegVar: unexpected case."
-                            SoARv regvar fieldRegs -> regvar
+                            SingleR _v -> error "Common.hs: getDataConRegFromRegVar: unexpected case."
+                            SoARv regvar _fieldRegs -> regvar
 
 getFieldRegFromRegVar :: (DataCon, Int) -> RegVar -> RegVar
 getFieldRegFromRegVar (dcon, idx) reg = case reg of 
-                            SingleR v -> error "Common.hs: getFieldRegFromRegVar: unexpected case."
-                            SoARv regvar fieldRegs -> case L.lookup (dcon, idx) fieldRegs of 
+                            SingleR _v -> error "Common.hs: getFieldRegFromRegVar: unexpected case."
+                            SoARv _regvar fieldRegs -> case L.lookup (dcon, idx) fieldRegs of
                                                         Just freg -> freg
                                                         Nothing -> error "getFieldRegFromRegVar: Field location not found!"
     

--- a/gibbon-compiler/src/Gibbon/Compiler.hs
+++ b/gibbon-compiler/src/Gibbon/Compiler.hs
@@ -56,7 +56,6 @@ import           Gibbon.L2.Interp ( Store, emptyStore )
 -- Compiler passes
 import qualified Gibbon.L0.Typecheck as L0
 import qualified Gibbon.L0.Specialize2 as L0
-import qualified Gibbon.L0.ElimNewtype as L0
 import qualified Gibbon.L1.Typecheck as L1
 import qualified Gibbon.L2.Typecheck as L2
 import qualified Gibbon.L3.Typecheck as L3
@@ -80,7 +79,6 @@ import           Gibbon.Passes.InferRegionScope (inferRegScope)
 import           Gibbon.Passes.RouteEnds      (routeEnds)
 import           Gibbon.Passes.FollowPtrs     (followPtrs)
 import           Gibbon.NewL2.FromOldL2       (fromOldL2)
-import           Gibbon.Passes.ThreadRegions  (threadRegions)
 import           Gibbon.Passes.ThreadRegions2  (threadRegions2)
 import           Gibbon.Passes.InferFunAllocs (inferFunAllocs)
 import           Gibbon.Passes.Cursorize      (cursorize)
@@ -98,7 +96,6 @@ import           Gibbon.Passes.HoistBoundsCheck (hoistBoundsCheckProg)
 import           Gibbon.Passes.ReorderLetExprs (reorderLetExprs)
 import           Gibbon.Pretty
 import           Gibbon.L1.GenSML
-import qualified Data.Tree as L2
 -- Configuring and launching the compiler.
 --------------------------------------------------------------------------------
 

--- a/gibbon-compiler/src/Gibbon/HaskellFrontend.hs
+++ b/gibbon-compiler/src/Gibbon/HaskellFrontend.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP              #-}
 {-# LANGUAGE LambdaCase       #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards  #-}
@@ -6,7 +7,10 @@ module Gibbon.HaskellFrontend
   ( parseFile, primMap, multiArgsToOne, desugarLinearExts ) where
 
 import           Control.Monad
-import           Data.Foldable ( foldrM, foldl' )
+import           Data.Foldable ( foldrM )
+#if !MIN_VERSION_base(4,21,0)
+import           Data.Foldable ( foldl' )
+#endif
 import           Data.Maybe (catMaybes, isJust)
 import qualified Data.Map as M
 import qualified Data.Set as S

--- a/gibbon-compiler/src/Gibbon/L1/GenSML.hs
+++ b/gibbon-compiler/src/Gibbon/L1/GenSML.hs
@@ -369,6 +369,7 @@ ppTy1 ty1 = case ty1 of
   SymTy -> _
   PtrTy -> _
   CursorTy -> _
+  _ -> error "ppTy1: unexpected type"
 
 printerTy1 :: Ty1 -> Doc -> Doc
 printerTy1 ty1 d = case ty1 of
@@ -432,6 +433,7 @@ printerTy1 ty1 d = case ty1 of
   IntHashTy -> _
   PtrTy -> _
   CursorTy -> _
+  _ -> error "printerTy1: unexpected type"
 
 printer :: Doc -> Doc -> Doc
 printer p d = parens $ "print" <> parens (p <> ".toString" <> parens d)

--- a/gibbon-compiler/src/Gibbon/L2/Interp.hs
+++ b/gibbon-compiler/src/Gibbon/L2/Interp.hs
@@ -292,6 +292,8 @@ interpExt :: SizeEnv -> RunConfig -> ValEnv Var Exp2 -> DDefs Ty2 -> M.Map Var (
            -> E2Ext LocVar Ty2 -> InterpM Store Exp2 (Value Exp2, Size)
 interpExt sizeEnv rc env ddefs fenv ext =
   case ext of
+    LetRegE{} -> error "L2.Interp: LetRegE not handled."
+    BoundsCheckVector{} -> error "L2.Interp: BoundsCheckVector not handled."
     LetRegionE reg _ _ bod -> do
       let regVar = case (regionToVar reg) of 
                              SingleR v -> v
@@ -304,6 +306,10 @@ interpExt sizeEnv rc env ddefs fenv ext =
 
     LetLocE loc locexp bod ->
       case locexp of
+        GenSoALoc{} -> error "L2.Interp: GenSoALoc not handled."
+        GetDataConLocSoA{} -> error "L2.Interp: GetDataConLocSoA not handled."
+        GetFieldLocSoA{} -> error "L2.Interp: GetFieldLocSoA not handled."
+        AssignLE{} -> error "L2.Interp: AssignLE not handled."
         StartOfRegionLE reg -> do
           let regVar = case (regionToVar reg) of 
                              SingleR v -> v

--- a/gibbon-compiler/src/Gibbon/L2/Syntax.hs
+++ b/gibbon-compiler/src/Gibbon/L2/Syntax.hs
@@ -224,9 +224,9 @@ data PreLocExp loc = StartOfRegionLE Region
                    -- | AfterVectorLE (PreLocExp loc) [PreLocExp loc] loc
                      -- Compute new SoA location from an old SoA location
                      -- Not sure this is fully needed 
-								     -- (PreLocExp loc) -> expression for arithmetic on data constructor buffer 
-								     -- [PreLocExp loc] -> expressions for arithmetic on each field location 
-								     -- loc, store the old loc, why? -- capture more metadata, also style
+                     -- (PreLocExp loc) -> expression for arithmetic on data constructor buffer
+                     -- [PreLocExp loc] -> expressions for arithmetic on each field location
+                     -- loc, store the old loc, why? -- capture more metadata, also style
   deriving (Read, Show, Eq, Ord, Functor, Generic, NFData)
 
 
@@ -265,6 +265,8 @@ instance FreeVars (E2Ext l d) where
      AllocateScalarsHere{}  -> S.empty
      SSPush{} -> S.empty
      SSPop{} -> S.empty
+     LetRegE{} -> error "gFreeVars: LetRegE not implemented yet"
+     BoundsCheckVector{} -> error "gFreeVars: BoundsCheckVector not implemented yet"
 
 instance FreeVars LocExp where
   gFreeVars e =
@@ -275,7 +277,7 @@ instance FreeVars LocExp where
       --GetDataConLocSoA loc -> S.fromList $ varsInLocVar loc
       --GetFieldLocSoA _ loc -> S.fromList $ varsInLocVar loc
       --GenSoALoc loc flocs -> S.fromList (varsInLocVar loc) `S.union` (S.fromList $ L.concatMap (\(_, loc) -> varsInLocVar loc) flocs)
-      AfterVariableLE v loc _ -> S.fromList [v]
+      AfterVariableLE v _loc _ -> S.fromList [v]
       _ -> S.empty
 
 instance (Out l, Out d, Show l, Show d) => Expression (E2Ext l d) where
@@ -299,6 +301,8 @@ instance (Out l, Out d, Show l, Show d) => Expression (E2Ext l d) where
       AllocateScalarsHere{} -> False
       SSPush{} -> False
       SSPop{} -> False
+      LetRegE{} -> error "isTrivial: LetRegE not implemented yet"
+      BoundsCheckVector{} -> error "isTrivial: BoundsCheckVector not implemented yet"
 
 instance (Out l, Show l, Typeable (E2 l (UrTy l))) => Typeable (E2Ext l (UrTy l)) where
   gRecoverType ddfs env2 ex =
@@ -321,6 +325,8 @@ instance (Out l, Show l, Typeable (E2 l (UrTy l))) => Typeable (E2Ext l (UrTy l)
       AllocateScalarsHere{} -> ProdTy []
       SSPush{} -> ProdTy []
       SSPop{} -> ProdTy []
+      LetRegE{} -> error "gRecoverType: LetRegE not implemented yet"
+      BoundsCheckVector{} -> error "gRecoverType: BoundsCheckVector not implemented yet"
 
   gRecoverTypeLoc ddfs env2 ex =
     case ex of
@@ -342,6 +348,8 @@ instance (Out l, Show l, Typeable (E2 l (UrTy l))) => Typeable (E2Ext l (UrTy l)
       AllocateScalarsHere{} -> ProdTy []
       SSPush{} -> ProdTy []
       SSPop{} -> ProdTy []
+      LetRegE{} -> error "gRecoverTypeLoc: LetRegE not implemented yet"
+      BoundsCheckVector{} -> error "gRecoverTypeLoc: BoundsCheckVector not implemented yet"
 
 instance (Typeable (E2Ext l d),
           Expression (E2Ext l d),
@@ -375,6 +383,8 @@ instance (Typeable (E2Ext l d),
           AllocateScalarsHere{} -> return ([],ex)
           SSPush{} -> return ([],ex)
           SSPop{} -> return ([],ex)
+          LetRegE{} -> error "gFlattenGatherBinds: LetRegE not implemented yet"
+          BoundsCheckVector{} -> error "gFlattenGatherBinds: BoundsCheckVector not implemented yet"
 
     where go = gFlattenGatherBinds ddfs env
 
@@ -401,6 +411,8 @@ instance HasSimplifiableExt E2Ext l d => SimplifiableExt (PreExp E2Ext l d) (E2E
       AllocateScalarsHere{} -> ext
       SSPush{} -> ext
       SSPop{} -> ext
+      LetRegE{} -> error "gInlineTrivExt: LetRegE not implemented yet"
+      BoundsCheckVector{} -> error "gInlineTrivExt: BoundsCheckVector not implemented yet"
 
 
 instance HasSubstitutableExt E2Ext l d => SubstitutableExt (PreExp E2Ext l d) (E2Ext l d) where
@@ -422,6 +434,8 @@ instance HasSubstitutableExt E2Ext l d => SubstitutableExt (PreExp E2Ext l d) (E
       AllocateScalarsHere{} -> ext
       SSPush{} -> ext
       SSPop{} -> ext
+      LetRegE{} -> error "gSubstExt: LetRegE not implemented yet"
+      BoundsCheckVector{} -> error "gSubstExt: BoundsCheckVector not implemented yet"
 
   gSubstEExt old new ext =
     case ext of
@@ -441,6 +455,8 @@ instance HasSubstitutableExt E2Ext l d => SubstitutableExt (PreExp E2Ext l d) (E
       AllocateScalarsHere{} -> ext
       SSPush{} -> ext
       SSPop{} -> ext
+      LetRegE{} -> error "gSubstEExt: LetRegE not implemented yet"
+      BoundsCheckVector{} -> error "gSubstEExt: BoundsCheckVector not implemented yet"
 
 instance HasRenamable E2Ext l d => Renamable (E2Ext l d) where
   gRename env ext =
@@ -461,6 +477,8 @@ instance HasRenamable E2Ext l d => Renamable (E2Ext l d) where
       AllocateScalarsHere{} -> ext
       SSPush{} -> ext
       SSPop{} -> ext
+      LetRegE{} -> error "gRename: LetRegE not implemented yet"
+      BoundsCheckVector{} -> error "gRename: BoundsCheckVector not implemented yet"
 
 -- | Our type for functions grows to include effects, and explicit universal
 -- quantification over location/region variables.
@@ -607,7 +625,6 @@ regionToVar r = case r of
                   VarR  v   -> SingleR v
                   MMapR v   -> SingleR v
                   SoAR reg fieldRegs -> SoARv (regionToVar reg) (L.map (\(k, freg) -> (k, regionToVar freg)) fieldRegs)
-                  _ -> error "L2/Syntax.hs: regionToVar: unexpected case."
 
 getAllRegions :: Region -> [Region]
 getAllRegions r = case r of 
@@ -746,13 +763,13 @@ outLocVars ty = L.map (\(LRM l _ _) -> l) $
 
 outRegVars :: ArrowTy2 ty2 -> [RegVar]
 outRegVars ty = L.concatMap (\(LRM _ r _) -> case r of
-                                          SoAR rr fieldRegions -> [regionToVar r]
+                                          SoAR _rr _fieldRegions -> [regionToVar r]
                                           _ -> [regionToVar r] 
                       ) $ L.filter (\(LRM _ _ m) -> m == Output) (locVars ty)
 
 inRegVars :: ArrowTy2 ty2 -> [RegVar]
 inRegVars ty = L.nub $ L.concatMap (\(LRM _ r _) -> case r of 
-                                                SoAR rr fieldRegions -> [regionToVar r]
+                                                SoAR _rr _fieldRegions -> [regionToVar r]
                                                 _ -> [regionToVar r]
                       ) $ L.filter (\(LRM _ _ m) -> m == Input) (locVars ty)
 
@@ -912,6 +929,8 @@ revertExp ex =
         AllocateScalarsHere{} -> error "revertExp: TODO AddFixed."
         SSPush{} -> error "revertExp: TODO SSPush."
         SSPop{} -> error "revertExp: TODO SSPop."
+        LetRegE{} -> error "revertExp: TODO LetRegE"
+        BoundsCheckVector{} -> error "revertExp: TODO BoundsCheckVector"
     MapE{}  -> error $ "revertExp: TODO MapE"
     FoldE{} -> error $ "revertExp: TODO FoldE"
   where
@@ -981,6 +1000,8 @@ occurs w ex =
         AllocateScalarsHere{} -> False
         SSPush{} -> False
         SSPop{} -> False
+        LetRegE{} -> error "occurs: TODO LetRegE"
+        BoundsCheckVector{} -> error "occurs: TODO BoundsCheckVector"
     MapE{}  -> error "occurs: TODO MapE"
     FoldE{} -> error "occurs: TODO FoldE"
   where
@@ -1108,6 +1129,8 @@ depList = L.map (\(a,b) -> (a,a,b)) . M.toList . go M.empty
               SSPop{} -> acc
               StartOfPkdCursor w -> go acc (VarE w)
               TagCursor a b -> go (go acc (VarE a)) (VarE b)
+              LetRegE{} -> error "depList: TODO LetRegE"
+              BoundsCheckVector{} -> error "depList: TODO BoundsCheckVector"
 
       dep :: PreLocExp LocVar -> [FreeVarsTy]
       dep ex =
@@ -1118,6 +1141,10 @@ depList = L.map (\(a,b) -> (a,a,b)) . M.toList . go M.empty
           InRegionLE r  -> [fromRegVarToFreeVarsTy (regionToVar r)]
           FromEndLE loc -> [fromLocVarToFreeVarsTy loc]
           FreeLE -> []
+          GenSoALoc{} -> error "dep: TODO GenSoALoc"
+          GetDataConLocSoA{} -> error "dep: TODO GenDataConLocSoA"
+          GetFieldLocSoA{} -> error "dep: TODO GetFieldLocSoA"
+          AssignLE{} -> error "dep: TODO AssignLE"
 
 -- TODO: VS: I don't think region vars are handled properly here. 
 allFreeVars :: Exp2 -> S.Set FreeVarsTy
@@ -1145,7 +1172,7 @@ allFreeVars ex =
         LetParRegionE r _ _ bod -> S.delete (R $ regionToVar r) (allFreeVars bod)
         LetLocE loc locexp bod -> let locs_locexp = case locexp of 
                                                       AfterConstantLE _ loc   -> S.singleton $ fromLocVarToFreeVarsTy loc
-                                                      AfterVariableLE v loc _ -> S.fromList [fromLocVarToFreeVarsTy loc]
+                                                      AfterVariableLE _ loc _ -> S.fromList [fromLocVarToFreeVarsTy loc]
                                                       -- All the locations inside an SoA loc are also free. 
                                                       -- TODO this works since locvar is not recursive but this needs to change
                                                       GetDataConLocSoA loc -> S.fromList $ L.map (fromLocVarToFreeVarsTy . singleLocVar) (varsInLocVar loc)
@@ -1172,6 +1199,8 @@ allFreeVars ex =
         AllocateScalarsHere loc -> S.singleton (fromLocVarToFreeVarsTy loc)
         SSPush _ a b _ -> S.fromList [(fromLocVarToFreeVarsTy a), (fromLocVarToFreeVarsTy b)]
         SSPop _ a b -> S.fromList [(fromLocVarToFreeVarsTy a), (fromLocVarToFreeVarsTy b)]
+        LetRegE{} -> error "allFreeVars: TODO LetRegE"
+        BoundsCheckVector{} -> error "allFreeVars: TODO BoundsCheckVector"
     _ -> S.map V (gFreeVars ex)
 
 allFreeVars' :: Exp2 -> S.Set Var 
@@ -1231,6 +1260,8 @@ changeAppToSpawn v args2 ex1 =
         AllocateScalarsHere{} -> ex1
         SSPush{} -> ex1
         SSPop{} -> ex1
+        LetRegE{} -> error "changeAppToSpawn: TODO LetRegE"
+        BoundsCheckVector{} -> error "changeAppToSpawn: TODO BoundsCheckVector"
     MapE{}  -> error "addRANExp: TODO MapE"
     FoldE{}  -> error "addRANExp: TODO FoldE"
 
@@ -1249,4 +1280,4 @@ fromRegVarToLocVar reg = case reg of
 fromLocVarToRegVar :: LocVar -> RegVar
 fromLocVarToRegVar loc = case loc of 
   Single v -> SingleR v
-  SoA dcon fieldLocs -> SoARv (SingleR dcon) (L.map (\(k, floc) -> (k, fromLocVarToRegVar floc)) fieldLocs)  
+  SoA dcon fieldLocs -> SoARv (SingleR dcon) (L.map (\(k, floc) -> (k, fromLocVarToRegVar floc)) fieldLocs)

--- a/gibbon-compiler/src/Gibbon/L2/Typecheck.hs
+++ b/gibbon-compiler/src/Gibbon/L2/Typecheck.hs
@@ -683,7 +683,7 @@ tcExp ddfs env funs constrs regs tstatein exp =
 
                  RequestEndOf{} -> throwError $ GenericTC  "tcExp of PrimAppE: RequestEndOf not handled yet" exp
 
-      LetE (v, _ls, ty, e1@(AppE f _ls1 _)) e2 -> do
+      LetE (v, _ls, ty, e1@(AppE _f _ls1 _)) e2 -> do
         (ty1,tstate1) <- recur tstatein e1
         ensureEqualTyNoLoc exp ty1 ty
         let zipped = zip _ls _ls1
@@ -874,6 +874,8 @@ tcExp ddfs env funs constrs regs tstatein exp =
                                         -- get region for the data constructor buffer
                                         let r' = case r of 
                                                     SoAR dreg _ -> dreg
+                                                    _ -> error $ "L2.Typecheck.tcExp: GetDataConLocSoA: Expected SoAR region, got " ++ show r
+
                                         -- LetLocE dconLoc = getDataConLocSoA soa_loc
                                         -- dbgTraceIt "print reg: " dbgTraceIt (sdoc r') dbgTraceIt "end print reg.\n" 
                                         let tstate1 = extendTS loc (Output,True) $ tstatein
@@ -886,7 +888,8 @@ tcExp ddfs env funs constrs regs tstatein exp =
                                               r <- getRegion exp constrs soa_loc
                                               -- get the region of the field location 
                                               let Just r' = case r of 
-                                                             SoAR dreg fieldRegions -> lookup key fieldRegions
+                                                             SoAR _dreg fieldRegions -> lookup key fieldRegions
+                                                             _ -> error $ "L2.Typecheck.tcExp: GetFieldLocSoA: Expected SoAR region, got " ++ show r
                                               let tstate1 = extendTS loc (Output, True) $ tstatein 
                                               let constrs1 = extendConstrs (InRegionC loc r') $ constrs
                                               (ty, tstate2) <- tcExp ddfs env' funs constrs1 regs tstate1 e
@@ -942,6 +945,10 @@ tcExp ddfs env funs constrs regs tstatein exp =
         -- (ty,tstate1) <- recur tstatein (VarE v)
         -- ensureEqualTy (VarE v) ty CursorTy
         return (ProdTy [], tstatein)
+
+      Ext (LetRegE _ _ _) -> throwError $ GenericTC "LetRegE not handled" exp
+
+      Ext (BoundsCheckVector _) -> throwError $ GenericTC "BoundsCheckVector not handled" exp
 
     where recur ts e = tcExp ddfs env funs constrs regs ts e
           checkListElemTy el_ty =
@@ -1098,10 +1105,10 @@ getRegion exp (ConstraintSet cs) l = go $ S.toList cs
 -- | Get the regions mentioned in the location bindings in a function type.
 funRegs :: [LRM] -> RegionSet
 funRegs ((LRM _l r _m):lrms) =
-    let (RegionSet rs) = funRegs lrms
-    in case r of 
-         _ -> RegionSet $ S.insert r rs
-         SoAR _ _ -> error "TODO: Typecheck: implement SoA Region."
+    let
+      (RegionSet rs) = funRegs lrms
+    in
+      RegionSet $ S.insert r rs
 funRegs [] = RegionSet $ S.empty
 
 globalReg :: Region
@@ -1130,7 +1137,7 @@ funTState [] = LocationTypeState $ M.empty
 -- | Look up the type of a variable from the environment
 -- Includes an expression for error reporting.
 lookupVar :: Env2 FreeVarsTy Ty2 -> FreeVarsTy -> Exp -> TcM Ty2
-lookupVar env l exp =
+lookupVar env l _exp =
     case M.lookup l $ vEnv env of
       Nothing -> error $ "L2/Typecheck.hs: lookupVar: Variable not found in env."++ sdoc l
       Just ty -> return ty
@@ -1226,7 +1233,7 @@ ensurePackedLoc exp ty l =
 -- Includes an expression for error reporting.
 ensureDataCon :: Exp -> TyCon -> DataCon -> LocVar -> [Ty2] -> ConstraintSet -> TcM ()
 ensureDataCon exp dcty dc linit0 tys cs = case linit0 of
-                                       Single location -> (go Nothing linit0 tys)
+                                       Single _location -> (go Nothing linit0 tys)
                                           where 
                                             go Nothing linit ((PackedTy dc2 l):tys) = do
                                               ensureAfterConstant exp cs linit l
@@ -1267,13 +1274,13 @@ ensureDataCon exp dcty dc linit0 tys cs = case linit0 of
                                                 
                                                                       ) tys  
                                               -- Not self recursive fields
-                                              let unselfTys = L.foldl (\a idx-> a ++ [tys !! idx]
+                                              let _unselfTys = L.foldl (\a idx-> a ++ [tys !! idx]
                                                                                     ) [] unself_idxs
                                               -- Self recursive fields
                                               let selfTys = L.foldl (\a idx -> a ++ [tys !! idx]
                                                                                     ) [] self_idxs
 
-                                              let unselfWriteAtLocs = L.map (\idx -> lookup (dc, idx) fieldLocs) unself_idxs
+                                              let _unselfWriteAtLocs = L.map (\idx -> lookup (dc, idx) fieldLocs) unself_idxs
                                               -- ensure after Constant with head of selfTys
                                               _ <- do 
                                                   case selfTys of 
@@ -1286,13 +1293,14 @@ ensureDataCon exp dcty dc linit0 tys cs = case linit0 of
                                               _ <- do 
                                                   case selfTys of 
                                                     [] -> return () 
-                                                    x:rst -> case x of 
-                                                               PackedTy _ l@(SoA dcloc' fieldLocs') -> do
+                                                    x:_ -> case x of
+                                                               PackedTy _ (SoA _dcloc' fieldLocs') -> do
                                                                                                         --let nextWriteAtLocs = L.map (\idx -> lookup (dc, idx) fieldLocs') unself_idxs
-                                                                                                        let aliasLocs = L.map (\idx -> case (lookup (dc, idx) fieldLocs) of 
+                                                                                                        let _aliasLocs = L.map (\idx -> case (lookup (dc, idx) fieldLocs) of
                                                                                                                                                           Just l -> getAfterConstantAlias cs l
+                                                                                                                                                          Nothing -> error "enusreDataCon: Did not expect Nothing!"
                                                                                                                                     ) unself_idxs
-                                                                                                        let nextWriteAtLocs = L.map (\idx -> lookup (dc, idx) fieldLocs') unself_idxs
+                                                                                                        let _nextWriteAtLocs = L.map (\idx -> lookup (dc, idx) fieldLocs') unself_idxs
                                                                                                         -- dbgTraceIt "Print line 1241: " dbgTraceIt (sdoc (aliasLocs)) dbgTraceIt "End\n"
                                                                                                         {- VS typechecking fails? Why is this not working ??? -}
                                                                                                         -- _ <- mapM (\(Just l1, Just l2, ty) -> case ty of 
@@ -1303,6 +1311,7 @@ ensureDataCon exp dcty dc linit0 tys cs = case linit0 of
                                                                                                         --                                           PackedTy{} -> ensureAfterPacked exp cs l1 l2
                                                                                                         --                                           _ -> ensureAfterConstant exp cs l1 l2) (zip3 aliasLocs nextWriteAtLocs unselfTys)
                                                                                                         return ()
+                                                               _ -> error "ensureDataCon: Did not expected unpacked type!"
                                               -- dbgTraceIt "Print in ensure data con" dbgTraceIt (sdoc (unselfTys, selfTys, unselfWriteAtLocs)) dbgTraceIt "End\n"
                                               return ()
 

--- a/gibbon-compiler/src/Gibbon/L3/Syntax.hs
+++ b/gibbon-compiler/src/Gibbon/L3/Syntax.hs
@@ -148,6 +148,10 @@ instance FreeVars (E3Ext l d) where
       SSPush _ a b _ -> S.fromList [a,b]
       SSPop _ a b -> S.fromList [a,b]
       Assert a -> gFreeVars a
+      MakeCursorArray {} -> error "gFreeVars: MakeCursorArray not handled"
+      IndexCursorArray {} -> error "gFreeVars: IndexCursorArray not handled"
+      CastPtr {} -> error "gFreeVars: CastPtr not handled"
+      BoundsCheckVector {} -> error "gFreeVars: BoundsCheckVector not handled"
 
 
 instance (Out l, Out d, Show l, Show d) => Expression (E3Ext l d) where
@@ -158,11 +162,19 @@ instance (Out l, Out d, Show l, Show d) => Expression (E3Ext l d) where
 instance (Out l, Show l, Typeable (PreExp E3Ext l (UrTy l))) => Typeable (E3Ext l (UrTy l)) where
     gRecoverType _ddfs _env2 NullCursor = CursorTy
     gRecoverType ddfs env2 (RetE ls)    = ProdTy $ L.map (gRecoverType ddfs env2) ls
+    gRecoverType _ _ (MakeCursorArray {}) = error "gRecoverType: MakeCursorArray not handled"
+    gRecoverType _ _ (IndexCursorArray {}) = error "gRecoverType: IndexCursorArray not handled"
+    gRecoverType _ _ (CastPtr {}) = error "gRecoverType: CastPtr not handled"
+    gRecoverType _ _ (BoundsCheckVector {}) = error "gRecoverType: BoundsCheckVector not handled"
     gRecoverType _ _ _ = error "L3.gRecoverType"
 
 
     gRecoverTypeLoc _ddfs _env2 NullCursor = CursorTy
     gRecoverTypeLoc ddfs env2 (RetE ls)    = ProdTy $ L.map (gRecoverTypeLoc ddfs env2) ls
+    gRecoverTypeLoc _ _ (MakeCursorArray {}) = error "gRecoverType: MakeCursorArray not handled"
+    gRecoverTypeLoc _ _ (IndexCursorArray {}) = error "gRecoverType: IndexCursorArray not handled"
+    gRecoverTypeLoc _ _ (CastPtr {}) = error "gRecoverType: CastPtr not handled"
+    gRecoverTypeLoc _ _ (BoundsCheckVector {}) = error "gRecoverType: BoundsCheckVector not handled"
     gRecoverTypeLoc _ _ _ = error "L3.gRecoverTypeLoc"
 
 instance (Show l, Out l) => Flattenable (E3Ext l (UrTy l)) where
@@ -185,6 +197,10 @@ instance HasSubstitutableExt E3Ext l d => SubstitutableExt (PreExp E3Ext l d) (E
       AddCursor v bod      -> AddCursor v (gSubst old new bod)
       SubPtr v w           -> SubPtr v w
       LetAvail ls bod      -> LetAvail ls (gSubst old new bod)
+      MakeCursorArray{}    -> ext
+      IndexCursorArray{}   -> ext
+      CastPtr{}            -> ext
+      BoundsCheckVector{}  -> ext
       _ -> ext
 
   gSubstEExt old new ext =
@@ -194,6 +210,10 @@ instance HasSubstitutableExt E3Ext l d => SubstitutableExt (PreExp E3Ext l d) (E
       AddCursor v bod   -> AddCursor v (gSubstE old new bod)
       SubPtr v w        -> SubPtr v w
       LetAvail ls b     -> LetAvail ls (gSubstE old new b)
+      MakeCursorArray{}    -> ext
+      IndexCursorArray{}   -> ext
+      CastPtr{}            -> ext
+      BoundsCheckVector{}  -> ext
       _ -> ext
 
 instance HasRenamable E3Ext l d => Renamable (E3Ext l d) where
@@ -239,6 +259,10 @@ instance HasRenamable E3Ext l d => Renamable (E3Ext l d) where
       SSPush a b c d -> SSPush a (go b) (go c) d
       SSPop a b c -> SSPop a (go b) (go c)
       Assert e -> Assert (go e)
+      MakeCursorArray{} -> error "gRename: MakeCursorArray not handled"
+      IndexCursorArray{} -> error "gRename: IndexCursorArray not handled"
+      CastPtr{} -> error "gRename: CastPtr not handled"
+      BoundsCheckVector{} -> error "gRename: BoundsCheckVector not handled"
     where
       go :: forall a. Renamable a => a -> a
       go = gRename env
@@ -288,7 +312,7 @@ cursorizeTy ty =
     PDictTy k v   -> PDictTy (cursorizeTy k) (cursorizeTy v)
     PackedTy _ l    -> case l of 
                            Single _ -> ProdTy [CursorTy, CursorTy]
-			   SoA _ flds -> ProdTy [CursorArrayTy (1 + length flds), CursorArrayTy (1 + length flds)]
+                           SoA _ flds -> ProdTy [CursorArrayTy (1 + length flds), CursorArrayTy (1 + length flds)]
     VectorTy el_ty' -> VectorTy $ cursorizeTy el_ty'
     ListTy el_ty'   -> ListTy $ cursorizeTy el_ty'
     PtrTy    -> PtrTy
@@ -297,6 +321,7 @@ cursorizeTy ty =
     SymSetTy -> SymSetTy
     SymHashTy-> SymHashTy
     IntHashTy-> IntHashTy
+    CursorArrayTy {} -> error "cursorizeTy: CursorArrayTy not handled"
 
 -- | Map exprs with an initial type environment:
 -- Exactly the same function that was in L2 before

--- a/gibbon-compiler/src/Gibbon/L3/Typecheck.hs
+++ b/gibbon-compiler/src/Gibbon/L3/Typecheck.hs
@@ -242,6 +242,8 @@ tcExp isSoA isPacked ddfs env exp = do
           ety <- go rhs
           ensureEqualTyModCursor isSoA rhs ety BoolTy
           return (ProdTy [])
+
+        CastPtr{} -> error "tcExp: CastPtr not handled"
         
         {- VS: TODO: we should check the bounds of index cursory array -}
         IndexCursorArray v _ -> do
@@ -784,7 +786,7 @@ tcExp isSoA isPacked ddfs env exp = do
         _ -> throwError $ GenericTC ("Expected expression to be SymDict type:" ++ sdoc rhs) exp
 
     
-    LetE (v, _, ty, Ext rhs@(CastPtr v' ty')) e -> do
+    LetE (v, _, ty, Ext rhs@(CastPtr _v' ty')) e -> do
        if (ty /= ty')
        then throwError $ GenericTC ("Expected expression to be SymDict type:" ++ sdoc rhs) exp
        else do  
@@ -933,7 +935,12 @@ tcProg isPacked prg@Prog{ddefs,fundefs,mainExp} = do
     tyEq CursorArrayTy{} PackedTy{} = True
     tyEq ty1 ty2 =
       case ty1 of
-        PackedTy{}  -> ty2 == ProdTy [CursorTy,CursorTy] || ty2 == ProdTy [CursorArrayTy{}, CursorArrayTy{}] || ty1 == ty2
+        PackedTy{}  ->
+          ty1 == ty2 ||
+          case ty2 of
+            ProdTy [CursorTy,CursorTy] -> True
+            ProdTy [CursorArrayTy _, CursorArrayTy _] -> True
+            _ -> False
         ProdTy tys2 -> let ProdTy tys1 = ty1
                        in  all (\(a,b) -> tyEq a b) (zip tys1 tys2)
         _ -> ty1 == ty2
@@ -995,8 +1002,6 @@ ensureEqualTyModCursor False _exp IntTy CursorTy = return CursorTy
 ensureEqualTyModCursor False _exp CursorTy IntTy = return CursorTy
 ensureEqualTyModCursor False exp (ProdTy ls1) (ProdTy ls2) =
   sequence_ [ ensureEqualTyModCursor False exp ty1 ty2 | (ty1,ty2) <- zip ls1 ls2] >>= \_ -> return (packedToCursor False (ProdTy ls1))
-ensureEqualTyModCursor s exp a b = ensureEqualTy exp a b
-
 
 ensureEqualTyModCursor True _exp (CursorArrayTy sz) (PackedTy _ _) = return (CursorArrayTy sz)
 ensureEqualTyModCursor True _exp (PackedTy _ _) (CursorArrayTy sz) = return (CursorArrayTy sz)
@@ -1004,17 +1009,15 @@ ensureEqualTyModCursor True _exp IntTy (CursorArrayTy sz) = return (CursorArrayT
 ensureEqualTyModCursor True _exp (CursorArrayTy sz) IntTy = return (CursorArrayTy sz)
 ensureEqualTyModCursor True exp (ProdTy ls1) (ProdTy ls2) =
   sequence_ [ ensureEqualTyModCursor True exp ty1 ty2 | (ty1,ty2) <- zip ls1 ls2] >>= \_ -> return (packedToCursor True (ProdTy ls1))
-ensureEqualTyModCursor s exp a b = ensureEqualTy exp a b
+ensureEqualTyModCursor _s exp a b = ensureEqualTy exp a b
 
 {- This assumes that The CursorArrayTy always has size 2 -}
 {- VS: we should ideally update the PackedTy type to have more information on its layout -}
 packedToCursor :: Bool -> Ty3 -> Ty3
 packedToCursor False (PackedTy _ _) = CursorTy
-packedToCursor False (PackedTy _ _) = CursorTy
-packedToCursor True  (PackedTy _ _) = CursorArrayTy 2
 packedToCursor True  (PackedTy _ _) = CursorArrayTy 2
 packedToCursor s (ProdTy tys) = ProdTy $ map (\ty -> packedToCursor s ty) tys
-packedToCursor s ty = ty
+packedToCursor _s ty = ty
 
 compareModCursor :: Ty3 -> Ty3 -> Bool
 compareModCursor CursorTy (PackedTy _ _) = True

--- a/gibbon-compiler/src/Gibbon/Language.hs
+++ b/gibbon-compiler/src/Gibbon/Language.hs
@@ -532,6 +532,7 @@ hasPacked t =
     SymSetTy       -> False
     SymHashTy      -> False
     IntHashTy      -> False
+    CursorArrayTy{} -> False
 
 
 -- | Get all packed types in a type.
@@ -555,6 +556,7 @@ getPackedTys t =
     SymSetTy       -> []
     SymHashTy      -> []
     IntHashTy      -> []
+    CursorArrayTy{} -> []
 
 -- | Provide a size in bytes, if it is statically known.
 sizeOfTy :: UrTy a -> Maybe Int
@@ -576,7 +578,8 @@ sizeOfTy t =
     ArenaTy       -> Just 8
     SymSetTy      -> error "sizeOfTy: SymSetTy not handled."
     SymHashTy     -> error "sizeOfTy: SymHashTy not handled."
-    IntHashTy     -> error "sizeOfTy: SymHashTy not handled."
+    IntHashTy     -> error "sizeOfTy: IntHashTy not handled."
+    CursorArrayTy{} -> error "sizeOfTy: CursorArrayTy not handled."
 
 -- | Type of the arguments for a primitive operation.
 primArgsTy :: Prim (UrTy a) -> [UrTy a]

--- a/gibbon-compiler/src/Gibbon/Language/Syntax.hs
+++ b/gibbon-compiler/src/Gibbon/Language/Syntax.hs
@@ -164,7 +164,7 @@ lkp dds con =
           ++", in datatypes:\n  "++sdoc dds
 
 getCursorTypeForDataCon :: Out a => DDefs (UrTy a) -> DDef (UrTy a) -> UrTy a
-getCursorTypeForDataCon ddefs ddef@DDef{tyName, tyArgs, dataCons, memLayout} =
+getCursorTypeForDataCon ddefs DDef{tyName, dataCons, memLayout} =
   -- remove data constructors introduced by RAN
   let dataCons' = concatMap (\e@(dcon, _) -> if ('^' `elem` dcon)
                                        then []

--- a/gibbon-compiler/src/Gibbon/NewL2/FromOldL2.hs
+++ b/gibbon-compiler/src/Gibbon/NewL2/FromOldL2.hs
@@ -131,12 +131,12 @@ fromOldL2Exp ddefs fundefs locenv env2 ex =
                                                      lrem_end_reg = New.lremEndReg lrem
                                                      New.Loc lrem' = case lrem_reg of 
                                                                   SingleR _ -> New.Loc $ lrem { New.lremLoc = loc }
-                                                                  SoARv dcreg fregs -> case L.lookup (dcon, idx) fregs of 
+                                                                  SoARv _dcreg fregs -> case L.lookup (dcon, idx) fregs of
                                                                                             Just fr -> New.Loc $ lrem { New.lremLoc = loc, New.lremReg = fr }
                                                                                             Nothing -> New.Loc $ lrem { New.lremLoc = loc }
                                                      New.Loc lrem'' = case lrem_end_reg of 
                                                                       SingleR _ -> New.Loc lrem' 
-                                                                      SoARv dcreg fregs -> case L.lookup (dcon, idx) fregs of
+                                                                      SoARv _dcreg fregs -> case L.lookup (dcon, idx) fregs of
                                                                                                 Just fr -> New.Loc $ lrem' { New.lremEndReg = fr} 
                                                                                                 Nothing -> New.Loc lrem'
                                                     in New.Loc lrem''   
@@ -228,6 +228,8 @@ fromOldL2Exp ddefs fundefs locenv env2 ex =
 
         SSPop mode loc end_loc -> do
           pure $ Ext $ SSPop mode loc end_loc
+        LetRegE {} -> error "fromOldL2Exp: LetRegE not handled"
+        BoundsCheckVector {} -> error "fromOldL2Exp: BoundsCheckVector not handled"
 
     -- straightforward recursion
     VarE v -> pure $ VarE v
@@ -285,7 +287,7 @@ fromOldL2Exp ddefs fundefs locenv env2 ex =
         in New.Loc (New.LREM loc fieldRegVar fieldEndRegVar modality)
       GenSoALoc dloc fieldsLocs ->
         -- Get the single locs and build this part
-        let soa_loc = SoA (unwrapLocVar dloc) (map (\(d, flc) -> (d, flc)) fieldsLocs)  
+        let _soa_loc = SoA (unwrapLocVar dloc) (map (\(d, flc) -> (d, flc)) fieldsLocs)
             (New.Loc dlrem) = locenv0 # dloc
             dloc_reg = New.lremReg dlrem 
             dloc_end_reg = New.lremEndReg dlrem
@@ -301,6 +303,7 @@ fromOldL2Exp ddefs fundefs locenv env2 ex =
             modality = New.lremMode dlrem
             lrem = New.LREM loc soa_reg soa_end_reg modality
          in New.Loc lrem
+      AssignLE {} -> error "toLocArg: AssignLE not handled"
 
 
   updModality :: Ty2 -> LocEnv -> LocEnv
@@ -436,6 +439,8 @@ toOldL2Exp ex =
 
         SSPop mode loc end_loc -> do
           pure $ Ext $ SSPop mode loc end_loc
+        LetRegE {} -> error "toOldL2Exp: LetRegE not handled"
+        BoundsCheckVector {} -> error "toOldL2Exp: BoundsCheckVector not handled"
 
     -- straightforward recursion
     VarE v -> pure $ VarE v

--- a/gibbon-compiler/src/Gibbon/NewL2/Syntax.hs
+++ b/gibbon-compiler/src/Gibbon/NewL2/Syntax.hs
@@ -114,6 +114,7 @@ toRegVar arg =
     Reg v _        -> v
     EndOfReg _ _ v -> v
     EndOfReg_Tagged v -> v
+    EndWitness {} -> error "toRegVar: EndWitness not handled"
 
 fromVarToSingleRegVar :: Var -> RegVar
 fromVarToSingleRegVar v = SingleR v
@@ -124,11 +125,9 @@ toLocVar arg =
   case arg of
     Loc lrm        -> lremLoc lrm
     EndWitness _ v -> v
-    Loc lrm        -> Old.fromRegVarToLocVar $ lremReg lrm
     Reg v _        -> Old.fromRegVarToLocVar v
     EndOfReg _ _ v -> Old.fromRegVarToLocVar v
     EndOfReg_Tagged v -> Old.fromRegVarToLocVar v
-    _ -> error "NewL2/Syntax.hs, toLocVar: unexpected case."
 
 
 fromLocArgToFreeVarsTy :: LocArg -> FreeVarsTy
@@ -136,11 +135,9 @@ fromLocArgToFreeVarsTy arg =
   case arg of
     Loc lrm        -> fromLocVarToFreeVarsTy $ lremLoc lrm
     EndWitness _ v -> fromLocVarToFreeVarsTy v
-    Loc lrm        -> fromRegVarToFreeVarsTy $ lremReg lrm
     Reg v _        -> fromRegVarToFreeVarsTy v
     EndOfReg _ _ v -> fromRegVarToFreeVarsTy v
     EndOfReg_Tagged v -> fromRegVarToFreeVarsTy v
-    _ -> error "NewL2/Syntax.hs, toLocVar: unexpected case."
 
 
 -- Returns the data constructor 
@@ -186,8 +183,8 @@ instance FreeVars LocExp where
     case e of
       -- Old.AfterConstantLE _ loc  -> S.singleton $ unwrapLocVar (toLocVar loc)
       -- Old.AfterVariableLE v loc _ -> S.fromList [v, unwrapLocVar (toLocVar loc)]
-      Old.AfterConstantLE _ loc  -> S.empty
-      Old.AfterVariableLE v loc _ -> S.fromList [v] 
+      Old.AfterConstantLE _ _loc  -> S.empty
+      Old.AfterVariableLE v _loc _ -> S.fromList [v]
       _ -> S.empty
 
 
@@ -212,6 +209,8 @@ instance Typeable (Old.E2Ext LocArg Ty2) where
       Old.AllocateScalarsHere{} -> MkTy2 $ ProdTy []
       Old.SSPush{}              -> MkTy2 $ ProdTy []
       Old.SSPop{}               -> MkTy2 $ ProdTy []
+      Old.LetRegE{}             -> error "gRecoverType: LetRegE not handled"
+      Old.BoundsCheckVector{}   -> error "gRecoverType: BoundsCheckVector not handled"
 
   gRecoverTypeLoc ddfs env2 ex =
     case ex of
@@ -233,6 +232,8 @@ instance Typeable (Old.E2Ext LocArg Ty2) where
       Old.AllocateScalarsHere{} -> MkTy2 $ ProdTy []
       Old.SSPush{}              -> MkTy2 $ ProdTy []
       Old.SSPop{}               -> MkTy2 $ ProdTy []
+      Old.LetRegE{}             -> error "gRecoverTypeLoc: LetRegE not handled"
+      Old.BoundsCheckVector{}   -> error "gRecoverTypeLoc: BoundsCheckVector not handled"
 
 
 
@@ -476,6 +477,8 @@ revertExp ex =
         Old.AllocateScalarsHere{} -> error "revertExp: TODO AddFixed."
         Old.SSPush{} -> error "revertExp: TODO SSPush."
         Old.SSPop{} -> error "revertExp: TODO SSPop."
+        Old.LetRegE {} -> error "revertExp: LetRegE not handled"
+        Old.BoundsCheckVector {} -> error "revertExp: BoundsCheckVector not handled"
     MapE{}  -> error $ "revertExp: TODO MapE"
     FoldE{} -> error $ "revertExp: TODO FoldE"
   where
@@ -552,6 +555,8 @@ depList = L.map (\(a,b) -> (a,a,b)) . M.toList . go M.empty
               Old.SSPop{} -> acc
               Old.StartOfPkdCursor cur -> M.insertWith (++) (fromVarToFreeVarsTy cur) [(fromVarToFreeVarsTy cur)] acc
               Old.TagCursor a b -> M.insertWith (++) (fromVarToFreeVarsTy b) [(fromVarToFreeVarsTy b)] (M.insertWith (++) (fromVarToFreeVarsTy a) [(fromVarToFreeVarsTy a)] acc)
+              Old.LetRegE {} -> error "depList: LetRegE not handled"
+              Old.BoundsCheckVector {} -> error "depList: BoundsCheckVector not handled"
 
       dep :: Old.PreLocExp LocArg -> [FreeVarsTy]
       dep ex =
@@ -562,6 +567,10 @@ depList = L.map (\(a,b) -> (a,a,b)) . M.toList . go M.empty
           Old.InRegionLE r  -> [fromRegVarToFreeVarsTy $ Old.regionToVar r]
           Old.FromEndLE loc -> [fromLocVarToFreeVarsTy $ toLocVar loc]
           Old.FreeLE -> []
+          Old.GenSoALoc {} -> error "depList: GenSoALoc not handled"
+          Old.GetDataConLocSoA {} -> error "depList: GetDataConLocSoA not handled"
+          Old.GetFieldLocSoA {} -> error "depList: GetFieldLocSoA not handled"
+          Old.AssignLE {} -> error "depList: AssignLE not handled"
 
 -- gFreeVars ++ locations ++ region variables
 allFreeVars :: Exp2 -> S.Set FreeVarsTy
@@ -600,6 +609,8 @@ allFreeVars ex =
         Old.AllocateScalarsHere loc -> S.singleton $ fromLocVarToFreeVarsTy loc
         Old.SSPush _ a b _ -> S.fromList (map fromLocVarToFreeVarsTy [a,b])
         Old.SSPop _ a b -> S.fromList (map fromLocVarToFreeVarsTy [a,b])
+        Old.LetRegE {} -> error "allFreeVars: LetRegE not handled"
+        Old.BoundsCheckVector {} -> error "allFreeVars: BoundsCheckVector not handled"
     _ -> (S.map fromVarToFreeVarsTy $ gFreeVars ex)
 
 freeLocVars :: Exp2 -> [LocVar]

--- a/gibbon-compiler/src/Gibbon/NewL2/Syntax.hs
+++ b/gibbon-compiler/src/Gibbon/NewL2/Syntax.hs
@@ -94,9 +94,8 @@ instance NFData LREM where
   rnf (LREM a b c d)  = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
 
 fromLRM :: Old.LRM -> LREM
-fromLRM (Old.LRM loc reg mode) = case reg of 
-  _ -> LREM loc (Old.regionToVar reg) (toEndVRegVar (Old.regionToVar reg)) mode
-  Old.SoAR _ _ -> error "TODO: NewL2/Syntax.hs, fromLRM, implement SoA region."
+fromLRM (Old.LRM loc reg mode) =
+  LREM loc (Old.regionToVar reg) (toEndVRegVar (Old.regionToVar reg)) mode
 
 data LocArg = Loc LREM
             | EndWitness LREM LocVar

--- a/gibbon-compiler/src/Gibbon/Passes/AddCastInstructions.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/AddCastInstructions.hs
@@ -113,7 +113,7 @@ addCastsExp fundef cenv env ex =
           ([], cenv, new_env, [])
           (zip es tys_of_es)
       bod' <- addCastsExp fundef cenv' env' bod
-      let ex' = foldr (\ex acc -> ex acc) (LetE (v, locs, ty, ((MkProdE (L.reverse vars')))) bod') new_insts
+      let ex' = foldr (\e acc -> e acc) (LetE (v, locs, ty, ((MkProdE (L.reverse vars')))) bod') new_insts
       pure $ ex'
 
     -- LetE (v, locs, ty, rhs@(Ext (AppE f _locs args))) bod -> do

--- a/gibbon-compiler/src/Gibbon/Passes/AddRAN.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/AddRAN.hs
@@ -250,7 +250,7 @@ withRANDDefs :: Out a => S.Set TyCon -> DDefs (UrTy a) -> DDefs (UrTy a)
 withRANDDefs needRANsTyCons ddfs = M.map go ddfs
   where
     -- go :: DDef a -> DDef b
-    go dd@DDef{dataCons, memLayout} =
+    go dd@DDef{dataCons} =
       let dcons' = L.foldr (\(dcon,tys) acc ->
                               case numRANsDataCon ddfs dcon of
                                 0 -> acc
@@ -437,6 +437,10 @@ we need random access for that type.
                         AfterConstantLE _ lc   -> renv # lc
                         AfterVariableLE _ lc _ -> renv # lc
                         FromEndLE lc           -> renv # lc -- TODO: This needs to be fixed
+                        GenSoALoc {}           -> error "needsRANExp: GenSoALoc not handled"
+                        GetDataConLocSoA {}    -> error "needsRANExp: GetDataConLocSoA not handled"
+                        GetFieldLocSoA {}      -> error "needsRANExp: GetFieldLocSoA not handled"
+                        AssignLE {}            -> error "needsRANExp: AssignLE not handled"
             in needsRANExp ddefs fundefs env2 (M.insert loc reg renv) tcenv parlocss bod
         _ -> S.empty
     MapE{}     -> S.empty

--- a/gibbon-compiler/src/Gibbon/Passes/AddTraversals.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/AddTraversals.hs
@@ -104,6 +104,10 @@ addTraversalsExp ddefs fundefs env2 renv context ex =
                       AfterConstantLE _ lc   -> renv # lc
                       AfterVariableLE _ lc _ -> renv # lc
                       FromEndLE lc           -> renv # lc -- TODO: This needs to be fixed
+                      GenSoALoc {}           -> error "addTraversalsExp: GenSoALoc not handled"
+                      GetDataConLocSoA {}    -> error "addTraversalsExp: GetDataConLocSoA not handled"
+                      GetFieldLocSoA {}      -> error "addTraversalsExp: GetFieldLocSoA not handled"
+                      AssignLE {}            -> error "addTraversalsExp: AssignLE not handled"
           in Ext <$> LetLocE loc locexp <$>
                addTraversalsExp ddefs fundefs env2 (M.insert loc reg renv) context bod
         _ -> return ex

--- a/gibbon-compiler/src/Gibbon/Passes/CalculateBounds.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/CalculateBounds.hs
@@ -33,10 +33,12 @@ calculateBoundsFun ddefs env2 varSzEnv f@FunDef { funName, funBody, funTy, funAr
   if "_" `L.isPrefixOf` fromVar funName
     then return f
     else do
-      let locRegEnv = M.fromList $ map (\lv -> case (lrmReg lv) of 
-                                                      _ -> (lrmLoc lv, regionToVar (lrmReg lv))
-                                                      SoAR _ _ -> error "TODO: calculateBoundsFn SoA region not implemented."
-                                       ) (locVars funTy)
+      let locRegEnv = M.fromList $ map
+                        (
+                          \lv -> case (lrmReg lv) of
+                              SoAR _ _ -> error "TODO: calculateBoundsFn SoA region not implemented."
+                              _ -> (lrmLoc lv, regionToVar (lrmReg lv))
+                        ) (locVars funTy)
       let locTyEnv  = M.map (const $ BoundedSize 0) locRegEnv
       let argTys    = M.fromList $ zip funArgs (arrIns funTy)
       let env2'     = env2 { vEnv = argTys }
@@ -189,6 +191,10 @@ calculateBoundsExp ddefs env2 varSzEnv varLocEnv locRegEnv locOffEnv regSzEnv re
                           (InRegionLE r         ) -> (regionToVar r, Undefined)
                           (FromEndLE  l         ) -> (locRegEnv # l, Undefined)
                           FreeLE                  -> undefined
+                          GenSoALoc {}            -> error "calculateBoundsExp: GenSoALoc not handled"
+                          GetDataConLocSoA {}     -> error "calculateBoundsExp: GetDataConLocSoA not handled"
+                          GetFieldLocSoA {}       -> error "calculateBoundsExp: GetFieldLocSoA not handled"
+                          AssignLE {}             -> error "calculateBoundsExp: AssignLE not handled"
                     let lre = M.insert loc re locRegEnv
                     let loe = M.insert loc off locOffEnv
                     (ex1', re', rt') <- calculateBoundsExp ddefs env2 varSzEnv varLocEnv lre loe regSzEnv regTyEnv ex1
@@ -208,3 +214,5 @@ calculateBoundsExp ddefs env2 varSzEnv varLocEnv locRegEnv locOffEnv regSzEnv re
               AllocateScalarsHere{} -> error $ "todo: " ++ sdoc ex
               SSPush{}              -> error $ "todo: " ++ sdoc ex
               SSPop{}               -> error $ "todo: " ++ sdoc ex
+              LetRegE {}            -> error "calculateBoundsExp: LetRegE not handled"
+              BoundsCheckVector {}  -> error "calculateBoundsExp: BoundsCheckVector not handled"

--- a/gibbon-compiler/src/Gibbon/Passes/Codegen.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/Codegen.hs
@@ -1075,7 +1075,7 @@ codegenTail venv fenv sort_fns (LetPrimCallT bnds prm rnds body) ty sync_deps =
                    ifConds <- mapM (\(ProdTriv [(IntTriv i),(VarTriv bound), (VarTriv cur)]) -> 
                                            pure [cexp| ($id:cur + $int:i) > $id:bound |]
                                       ) rnds
-                   ifBody <- mapM (\(ProdTriv [(IntTriv i),(VarTriv bound), (VarTriv cur)]) -> 
+                   ifBody <- mapM (\(ProdTriv [(IntTriv _i),(VarTriv bound), (VarTriv cur)]) ->
                                        pure [ C.BlockStm  [cstm|  gib_grow_region(& $id:cur, & $id:bound); |] ]
                                   ) rnds
                    let condExpr = foldr1 (\c1 c2 -> [cexp| $exp:c1 || $exp:c2 |]) ifConds
@@ -1573,7 +1573,7 @@ codegenTail venv fenv sort_fns (LetPrimCallT bnds prm rnds body) ty sync_deps =
                         ptr' = codegenTriv venv ptr
                     return [ C.BlockDecl [cdecl| $ty:(codegenTy outT) $id:outV = ($ty:(codegenTy outT)) $exp:ptr'; |] ] 
 
-                 _ -> error $ "codegen: " ++ show prm ++ " unhandled."
+
 
        return $ pre ++ bod'
 
@@ -1653,7 +1653,7 @@ codegenTy TagTyBoxed  = [cty|typename GibBoxedTag|]
 codegenTy SymTy = [cty|typename GibSym|]
 codegenTy PtrTy = [cty|typename GibPtr|] -- char* - Hack, this could be void* if we have enough casts. [2016.11.06]
 codegenTy CursorTy = [cty|typename GibCursor|]
-codegenTy (CursorArrayTy size) = [cty|typename GibCursor* |]
+codegenTy (CursorArrayTy _size) = [cty|typename GibCursor* |]
 codegenTy RegionTy = [cty|typename GibChunk|]
 codegenTy ChunkTy = [cty|typename GibChunk|]
 codegenTy (ProdTy []) = [cty|unsigned char|]

--- a/gibbon-compiler/src/Gibbon/Passes/Cursorize.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/Cursorize.hs
@@ -1,4 +1,7 @@
-{-# OPTIONS_GHC -Wwarn #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+{-# OPTIONS_GHC -Wno-unused-local-binds  #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
 module Gibbon.Passes.Cursorize
   (cursorize) where
 
@@ -858,7 +861,6 @@ cursorizeExp freeVarToVarEnv lenv ddfs fundefs denv tenv senv ex =
           -- SingleR v -> cursorizePackedExp freeVarToVarEnv ddfs fundefs denv tenv senv bod
           -- SoARv dv _ -> cursorizePackedExp freeVarToVarEnv ddfs fundefs denv tenv senv bod
 
-        _ -> error $ "Unpexected Expression: " ++ show ext
 
     MapE{} -> error $ "TODO: cursorizeExp MapE"
     FoldE{} -> error $ "TODO: cursorizeExp FoldE"

--- a/gibbon-compiler/src/Gibbon/Passes/Cursorize.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/Cursorize.hs
@@ -4,7 +4,7 @@ module Gibbon.Passes.Cursorize
 import           Control.Monad (forM)
 import qualified Data.List as L
 import qualified Data.Map as M
-import           Data.Maybe (fromJust, listToMaybe)
+import           Data.Maybe (fromJust)
 import           Text.PrettyPrint.GenericPretty
 import           Data.Foldable ( foldlM, foldrM )
 
@@ -16,7 +16,7 @@ import           Gibbon.L3.Syntax hiding ( BoundsCheck, RetE, GetCilkWorkerNum, 
                                            TagCursor )
 import qualified Gibbon.L3.Syntax as L3
 import           Gibbon.Passes.AddRAN ( numRANsDataCon )
-import Data.Set (Set)
+
 
 {-
 
@@ -225,7 +225,7 @@ cursorizeFunDef useSoA ddefs fundefs FunDef{funName,funTy,funArgs,funBody,funMet
                                                                                                   Nothing -> error "cursorizeFunDef: unexpected location variable"
                                                                packed_cursor_ty = case l of 
                                                                                          Single _ -> Just l 
-                                                                                         SoA _ fields -> Just l
+                                                                                         SoA _ _fields -> Just l
                                                                loc_entry = (var_for_loc, packed_cursor_ty)
                                                                var_for_reg = case (M.lookup (fromRegVarToFreeVarsTy (toEndVRegVar $ regionToVar r)) freeVarToVarEnv') of 
                                                                                                   Just v -> v 
@@ -320,15 +320,15 @@ This is used to create bindings for input location variables.
            _ -> acc
 
     cursorizeArrowTy :: Bool -> ArrowTy2 Ty2 -> ([Ty3] , Ty3)
-    cursorizeArrowTy useSoA ty@ArrowTy2{arrIns,arrOut,locVars,locRets} =
+    cursorizeArrowTy useSoA' ty@ArrowTy2{arrIns,arrOut,locVars,locRets} =
       let
           -- Regions corresponding to ouput cursors. (See [Threading regions])
-          numOutRegs = length (outRegVars ty)
+          _numOutRegs = length (outRegVars ty)
           --outRegs = L.map (\_ -> CursorTy) [1..numOutRegs]
 
           outRegs = L.map (\r -> case r of
-                                   SingleR v -> CursorTy
-                                   SoARv dcr frs -> CursorArrayTy (1 + length frs)
+                                   SingleR _v -> CursorTy
+                                   SoARv _dcr frs -> CursorArrayTy (1 + length frs)
                           ) (outRegVars ty)
 
 
@@ -341,7 +341,7 @@ This is used to create bindings for input location variables.
           ret_curs = L.map (\lret -> case lret of
                                           EndOf (LRM l _ _) -> case l of 
                                                                   Single _ -> CursorTy 
-                                                                  SoA dcl flocs -> CursorArrayTy (1 + length flocs)
+                                                                  SoA _dcl flocs -> CursorArrayTy (1 + length flocs)
                                   
                            ) locRets
 
@@ -351,7 +351,7 @@ This is used to create bindings for input location variables.
                      _  -> ProdTy $ out_curs ++ [unTy2 arrOut]
 
           -- Packed types in the output then become end-cursors for those same destinations.
-          newOut = mapPacked (\var loc -> case loc of 
+          newOut = mapPacked (\_var loc -> case loc of
                                                Single _  -> ProdTy [CursorTy, CursorTy]
                                                SoA _ fields -> ProdTy [CursorArrayTy (1 + length fields), CursorArrayTy (1 + length fields)]
                            
@@ -376,7 +376,7 @@ This is used to create bindings for input location variables.
 
           -- Packed types in the input now become (read-only) cursors.
 
-          newIns = if useSoA 
+          newIns = if useSoA'
                    then map (cursorizeInTy) in_tys
                    else map (constPacked CursorTy) in_tys
 

--- a/gibbon-compiler/src/Gibbon/Passes/Cursorize.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/Cursorize.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wwarn #-}
 module Gibbon.Passes.Cursorize
   (cursorize) where
 

--- a/gibbon-compiler/src/Gibbon/Passes/DirectL3.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/DirectL3.hs
@@ -95,3 +95,4 @@ directL3 prg@(Prog ddfs fndefs mnExp) = do
         SymSetTy -> SymSetTy
         SymHashTy -> SymHashTy
         IntHashTy -> IntHashTy
+        CursorArrayTy {} -> error "directL3: CursorArrayTy not handled"

--- a/gibbon-compiler/src/Gibbon/Passes/FindWitnesses.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/FindWitnesses.hs
@@ -217,5 +217,5 @@ mapMExprs fn (Prog ddfs fundefs mainExp) =
   where funEnv = initFunEnv' fundefs
 
 ex_freeVars :: Exp2 -> Set.Set FreeVarsTy
-ex_freeVars exp = allFreeVars exp
+ex_freeVars ex = allFreeVars ex
 -- ex_freeVars = gFreeVars

--- a/gibbon-compiler/src/Gibbon/Passes/FollowPtrs.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/FollowPtrs.hs
@@ -40,7 +40,7 @@ followPtrs (Prog ddefs fundefs mainExp) = do
             if no_copies
             then do
               indir_ptrv <- gensym "indr"
-              indir_ptrv_loc <- freshCommonLoc "indr" scrt_loc
+              _indir_ptrv_loc <- freshCommonLoc "indr" scrt_loc
               callv <- gensym "call"
               wc <- gensym "wildcard"
               indir_ptrloc <- freshCommonLoc "case" scrt_loc

--- a/gibbon-compiler/src/Gibbon/Passes/InferEffects.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/InferEffects.hs
@@ -179,6 +179,8 @@ inferExp ddfs fenv env dps expr =
     Ext (AllocateScalarsHere{}) -> (S.empty, Nothing)
     Ext (SSPush{}) -> (S.empty, Nothing)
     Ext (SSPop{}) -> (S.empty, Nothing)
+    Ext (LetRegE{}) -> error "inferEffects: LetRegE not handled"
+    Ext (BoundsCheckVector{}) -> error "inferEffects: BoundsCheckVector not handled"
 
   where
     packedLoc :: Ty2 -> Maybe LocVar

--- a/gibbon-compiler/src/Gibbon/Passes/InferFunAllocs.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/InferFunAllocs.hs
@@ -72,5 +72,7 @@ inferExp fenv expr =
     Ext (AllocateScalarsHere{}) -> False
     Ext (SSPush{})              -> False
     Ext (SSPop{})               -> False
+    Ext (LetRegE{}) -> error "inferFunAllocs: LetRegE not handled"
+    Ext (BoundsCheckVector{}) -> error "inferFunAllocs: BoundsCheckVector not handled"
   where
     go = inferExp fenv

--- a/gibbon-compiler/src/Gibbon/Passes/InferLocations.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/InferLocations.hs
@@ -2012,30 +2012,22 @@ cleanExp e =
                                                     oth -> []
                                          in (Ext (LetLocE loc lex e'), S.delete loc (S.union s' $ S.fromList ls))
                                     else (e',s')
-      Ext (LetLocE s@(SoA dloc flcs) lex@(GenSoALoc _ _) e) -> let (e',s') = cleanExp e
+      Ext (LetLocE s@(SoA dloc flcs) lex@(GenSoALoc dcloc flocs) e) -> let (e',s') = cleanExp e
                                               in if S.member s s'
-                                                 then let ls = case lex of
-                                                                  GenSoALoc dcloc flocs -> [dcloc] ++ P.map (\(_, ll) -> ll) flocs
+                                                 then let ls = [dcloc] ++ P.map (\(_, ll) -> ll) flocs
                                                        in (Ext (LetLocE s lex e'), S.delete s (S.union s' $ S.fromList ls))
                                                  else (e',s')
-      Ext (LetLocE s@(SoA dloc flcs) lex@(AssignLE _) e) -> let (e',s') = cleanExp e
+      Ext (LetLocE s@(SoA dloc flcs) lex@(AssignLE loc) e) -> let (e',s') = cleanExp e
                                               in if S.member s s'
-                                                 then let ls = case lex of
-                                                                  AssignLE loc -> [loc]
-                                                       in (Ext (LetLocE s lex e'), S.delete s (S.union s' $ S.fromList ls))
+                                                 then (Ext (LetLocE s lex e'), S.delete s (loc `S.insert` s'))
                                                  else (e' ,s')
       Ext (LetLocE s@(SoA dloc flcs) lex@(GetFieldLocSoA _ loc) e) -> let (e',s') = cleanExp e
                                               in if S.member s s'
-                                                 then let ls = case lex of
-                                                                  GetFieldLocSoA _ loc -> [loc]
-                                                       in (Ext (LetLocE s lex e'), S.delete s (S.union s' $ S.fromList ls))
+                                                 then (Ext (LetLocE s lex e'), S.delete s (loc `S.insert` s'))
                                                  else (e' ,s')
       Ext (LetLocE s@(SoA dloc flcs) lex e) -> let (e',s') = cleanExp e
                                               in if S.member s s'
-                                                 then let ls = case lex of
-                                                                  oth -> []
-                                                       in (Ext (LetLocE s lex e'), 
-                                                              S.delete s (S.union s' $ S.fromList ls))
+                                                 then (Ext (LetLocE s lex e'), S.delete s s')
                                                  else (e',s')
       --Ext (LetSoALocE loc e) -> let (e',s') = cleanExp e
       --                           in (Ext $ LetSoALocE loc e',s')

--- a/gibbon-compiler/src/Gibbon/Passes/InferLocations.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/InferLocations.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wwarn #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# OPTIONS_GHC -Wno-unused-matches #-}
 {-# LANGUAGE BlockArguments #-}

--- a/gibbon-compiler/src/Gibbon/Passes/InferLocations.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/InferLocations.hs
@@ -1,5 +1,4 @@
-{-# OPTIONS_GHC -Wwarn #-}
-{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# OPTIONS_GHC -Wno-unused-matches #-}
 {-# LANGUAGE BlockArguments #-}
 
@@ -435,7 +434,7 @@ freshTyLocs ty ddefs = do
                                             --return $ PackedTy tc newSoALoc
                                             dbuf' <- fresh
                                             let dcons = getConOrdering ddefs tc
-                                            locsForFields <- lift $ lift $convertTyHelperSoAParent tc ddefs dcons
+                                            locsForFields <- lift $ lift $ convertTyHelperSoAParent tc ddefs dcons
                                             let soaLocation = SoA (unwrapLocVar dbuf') locsForFields
                                             return $ PackedTy tc soaLocation
                             Single _ -> do
@@ -1891,6 +1890,8 @@ finishExp e =
       Ext (AllocateScalarsHere{}) -> err $ "todo: " ++ sdoc e
       Ext (SSPush{})              -> err $ "todo: " ++ sdoc e
       Ext (SSPop{})               -> err $ "todo: " ++ sdoc e
+      Ext (LetRegE{})             -> err $ "todo: " ++ sdoc e
+      Ext (BoundsCheckVector{})   -> err $ "todo: " ++ sdoc e
       MapE{}  -> err$ "MapE not supported"
       FoldE{} -> err$ "FoldE not supported"
 
@@ -2015,21 +2016,18 @@ cleanExp e =
                                               in if S.member s s'
                                                  then let ls = case lex of
                                                                   GenSoALoc dcloc flocs -> [dcloc] ++ P.map (\(_, ll) -> ll) flocs
-                                                                  oth -> []
                                                        in (Ext (LetLocE s lex e'), S.delete s (S.union s' $ S.fromList ls))
                                                  else (e',s')
       Ext (LetLocE s@(SoA dloc flcs) lex@(AssignLE _) e) -> let (e',s') = cleanExp e
                                               in if S.member s s'
                                                  then let ls = case lex of
                                                                   AssignLE loc -> [loc]
-                                                                  oth -> []
                                                        in (Ext (LetLocE s lex e'), S.delete s (S.union s' $ S.fromList ls))
                                                  else (e' ,s')
       Ext (LetLocE s@(SoA dloc flcs) lex@(GetFieldLocSoA _ loc) e) -> let (e',s') = cleanExp e
                                               in if S.member s s'
                                                  then let ls = case lex of
                                                                   GetFieldLocSoA _ loc -> [loc]
-                                                                  oth -> []
                                                        in (Ext (LetLocE s lex e'), S.delete s (S.union s' $ S.fromList ls))
                                                  else (e' ,s')
       Ext (LetLocE s@(SoA dloc flcs) lex e) -> let (e',s') = cleanExp e
@@ -2054,6 +2052,8 @@ cleanExp e =
       Ext (AllocateScalarsHere{}) -> err $ "todo: " ++ sdoc e
       Ext (SSPush{})              -> err $ "todo: " ++ sdoc e
       Ext (SSPop{})               -> err $ "todo: " ++ sdoc e
+      Ext (LetRegE{})             -> err $ "todo: " ++ sdoc e
+      Ext (BoundsCheckVector{})   -> err $ "todo: " ++ sdoc e
       MapE{} -> err$ "MapE not supported"
       FoldE{} -> err$ "FoldE not supported"
 
@@ -2128,6 +2128,7 @@ fixProj renam pvar proj e =
 moveProjsAfterSync :: LocVar -> Exp2 -> Exp2
 moveProjsAfterSync sv ex = case sv of 
                                 l@(Single loc) -> go [] (S.singleton $ fromLocVarToFreeVarsTy l) ex
+                                SoA {} -> error "moveProjsAfterSync: unexpected SoA location"
   where
     go :: [Binds (Exp2)] -> S.Set FreeVarsTy -> Exp2 -> Exp2
     go acc1 pending ex =
@@ -2685,6 +2686,9 @@ fixRANs prg@(Prog defs funs main) = do
                      AllocateScalarsHere{} -> return ([],e0)
                      SSPush{}              -> return ([],e0)
                      SSPop{}               -> return ([],e0)
+                     LetRegE{}             -> return ([],e0)
+                     BoundsCheckVector{}   -> return ([],e0)
+
 
         LitE{}    -> return ([],e0)
         CharE{}   -> return ([],e0)

--- a/gibbon-compiler/src/Gibbon/Passes/InferLocations.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/InferLocations.hs
@@ -826,7 +826,7 @@ inferExp ddefs env@FullEnv{dataDefs} ex0 dest =
              -> (DataCon, [(Var,())], Exp1) ->
              TiM ((DataCon, [(Var,LocVar)], L2.Exp2), Ty2, [Constraint])
       doCase ddfs env src dst (con,vars,rhs) = do
-        let (tyc, (don, flds)) = lkp ddfs con
+        let (_tyc, (_don, flds)) = lkp ddfs con
         dflags <- getDynFlags
         let useSoA = gopt Opt_Packed_SoA dflags
         let zippedVars = zip vars flds
@@ -1179,7 +1179,7 @@ inferExp ddefs env@FullEnv{dataDefs} ex0 dest =
                             Just $ AfterCopyL loc1 v v' loc2 f lvs
                           afterVar _ = Nothing
                           -- dbgTrace minChatLvl "Print DataConE SoA case argsLs: " dbgTrace minChatLvl (sdoc (d, argLs, newLocs)) dbgTrace minChatLvl "End DataConE SoA case argLs.\n"
-                      let dataBufferLoc = Single dataBufferVar
+                      let _dataBufferLoc = Single dataBufferVar
                           -- Some locs need to be sequentialized with respect to the 
                           -- data contructor buffer. These are the recursive fields, 
                           -- the same datatype. 
@@ -1195,7 +1195,7 @@ inferExp ddefs env@FullEnv{dataDefs} ex0 dest =
                           -- dbgTrace minChatLvl "Print tuple line: 1023" dbgTrace minChatLvl (sdoc (idxsWriteDconBuf, idxsFields)) dbgTrace minChatLvl "End line 1023\n"
                           idxsWriteDconBuf' = L.reverse idxsWriteDconBuf  
                           idxsFields' = L.reverse idxsFields                                       
-                          argsLsDconBuf = L.map (\(Just idx) -> ls' !! idx) idxsWriteDconBuf'
+                          _argsLsDconBuf = L.map (\(Just idx) -> ls' !! idx) idxsWriteDconBuf'
                           dcArgDconBuf = L.map (\(Just idx) -> argLs !! idx) idxsWriteDconBuf'
                           locsDconBuf =  L.map (\(Just idx) -> locs !! idx) idxsWriteDconBuf' 
                           -- Other fields need to have constraints with their own output region.

--- a/gibbon-compiler/src/Gibbon/Passes/InferRegionScope.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/InferRegionScope.hs
@@ -87,21 +87,21 @@ inferRegScopeExpHelper ex rhs r env =
         let (g,_,vtxF) = graphFromEdges deps
           in case r of 
             -- VS: TODO: Handle case then field Regions also contain more factored out SoA regions.
-            SoAR dcr fieldRegs -> let regVLoc = R $ regionToVar r 
-                                      regVertex = case vtxF regVLoc of
-                                        Just x  -> x
-                                        Nothing -> error $ "No vertex for:" ++ sdoc r
-                                      retVertex = case vtxF retVar of
-                                        Just x  -> x
-                                        Nothing -> error $ "No vertex for:" ++ sdoc retVar
-                                      -- The value in the region  escapes the current scope if there's
-                                      -- a path between the region variable and the thing returned.
+            SoAR _dcr _fieldRegs -> let regVLoc = R $ regionToVar r
+                                        regVertex = case vtxF regVLoc of
+                                          Just x  -> x
+                                          Nothing -> error $ "No vertex for:" ++ sdoc r
+                                        retVertex = case vtxF retVar of
+                                          Just x  -> x
+                                          Nothing -> error $ "No vertex for:" ++ sdoc retVar
+                                        -- The value in the region  escapes the current scope if there's
+                                        -- a path between the region variable and the thing returned.
                                     in do dflags <- getDynFlags 
                                           let defaultMul = if (gopt Opt_BigInfiniteRegions dflags) ||
                                                        (gopt Opt_Gibbon1 dflags)
                                                     then BigInfinite
                                                     else Infinite
-                                          let isPath = path g retVertex regVertex
+                                          let _isPath = path g retVertex regVertex
                                           -- Not handling recursive SoA Regions
                                           -- let scopedDcr = case dcr of 
                                           --                     VarR dcrVar -> GlobR dcrVar defaultMul
@@ -163,7 +163,7 @@ inferRegScopeExp env ex =
 
         LetParRegionE r sz ty rhs ->
           case r of
-            SoAR dcr fieldRegs -> error "Did not handle SoAR in inferRegScopeExp."
+            SoAR _dcr _fieldRegs -> error "Did not handle SoAR in inferRegScopeExp."
             MMapR{} -> Ext . LetParRegionE r sz ty <$> go rhs
             _ ->
               let deps = depList ex
@@ -222,6 +222,8 @@ inferRegScopeExp env ex =
         AllocateScalarsHere{} -> return ex
         SSPush{} -> return ex
         SSPop{} -> return ex
+        LetRegE {} -> error "inferRegScopeExp: LetRegE not handled"
+        BoundsCheckVector {} -> error "inferRegScopeExp: BoundsCheckVector not handled"
 
     -- Straightforward recursion ...
     VarE{}     -> return ex

--- a/gibbon-compiler/src/Gibbon/Passes/Lower.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/Lower.hs
@@ -525,10 +525,10 @@ lower Prog{fundefs,ddefs,mainExp} = do
               SSPush{} -> syms
               SSPop{} -> syms
               Assert ex -> go ex
-              MakeCursorArray len vars -> syms
-              IndexCursorArray var idx -> syms
-              CastPtr var ty -> syms
-              _ -> error $ "Unexpected Ext: " ++ sdoc ex
+              MakeCursorArray _len _vars -> syms
+              IndexCursorArray _var _idx -> syms
+              CastPtr _var _ty -> syms
+              
           MapE{}         -> syms
           FoldE{}        -> syms
 
@@ -769,7 +769,7 @@ lower Prog{fundefs,ddefs,mainExp} = do
         tail free_reg sym_tbl bod
 
 
-    LetE (v, _, ty, (Ext (MakeCursorArray size vars))) bod ->
+    LetE (v, _, _, (Ext (MakeCursorArray size vars))) bod ->
       T.LetPrimCallT [(v, T.CursorArrayTy size)] T.MakeCursorArray [triv sym_tbl ("MakeCursorArray arg" ++ (show $ fromJust $ L.elemIndex var vars)) (VarE var) | var <- vars] <$>
         tail free_reg sym_tbl bod
     

--- a/gibbon-compiler/src/Gibbon/Passes/ParAlloc.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/ParAlloc.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wwarn #-}
 {-| Do all things necessary to compile parallel allocations to a single region.
 
 In the sequential semantics, (letloc-after x) can only run after x is written to

--- a/gibbon-compiler/src/Gibbon/Passes/ParAlloc.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/ParAlloc.hs
@@ -76,8 +76,8 @@ parAlloc Prog{ddefs,fundefs,mainExp} = do
           error "gibbon: Cannot compile parallel allocations in Gibbon1 mode."
 
         let initRegEnv = M.fromList $ map (\(LRM lc r _) -> case r of 
+                                                              SoAR _ _ -> error "TODO: parAlloc structure of arrays not implemented yet."
                                                               _ -> (lc, regionToVar r)
-                                                              SoAR _ _ -> error "TODO: parAlloc structure of arrays not implemented yet."  
                                           ) (locVars funTy)
             funArgs' = L.map fromVarToFreeVarsTy funArgs
             initTyEnv  = M.fromList $ zip funArgs' (arrIns funTy)

--- a/gibbon-compiler/src/Gibbon/Passes/ParAlloc.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/ParAlloc.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wwarn #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-| Do all things necessary to compile parallel allocations to a single region.
 
 In the sequential semantics, (letloc-after x) can only run after x is written to
@@ -136,10 +136,10 @@ parAllocExp ddefs fundefs env2 reg_env after_env mb_parent_id pending_binds spaw
                                        Nothing (M.elems (vEnv env2))
                         indr_dcon = Sf.headErr $ filter isIndirectionTag $ getConOrdering ddefs tycon
                         reg_from = case (reg_env # from) of
-                                          SingleR v -> v
+                                          SingleR v' -> v'
                                           SoARv _ _ -> error "parAlloc: did not expect an SoA region!"
                         reg_to = case (reg_env # to) of 
-                                          SingleR v -> v
+                                          SingleR v' -> v'
                                           SoARv _ _ -> error "parAlloc: did not expect an SoA region!"
                         rhs = Ext $ IndirectionE tycon indr_dcon (from, singleLocVar reg_from) (to, singleLocVar reg_to) (AppE "nocopy" [] [])
                     pure $ LetE (indr, [], PackedTy tycon from, rhs) acc)

--- a/gibbon-compiler/src/Gibbon/Passes/RegionsInwards.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/RegionsInwards.hs
@@ -1,4 +1,5 @@
-{-# OPTIONS_GHC -Wwarn #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+{-# OPTIONS_GHC -Wno-unused-matches  #-}
 module Gibbon.Passes.RegionsInwards (regionsInwards) where
 
 import Data.Foldable as F
@@ -7,7 +8,6 @@ import qualified Data.Map as M
 import Data.Maybe ()
 import qualified Data.Maybe as S
 import qualified Data.Set as S
-import Data.Text.Array (new)
 import Gibbon.Common
 import Gibbon.L2.Syntax
 import Text.PrettyPrint.GenericPretty
@@ -673,10 +673,10 @@ removeAliasedLocations env definedLocs ex =
               rhs' <- removeAliasedLocations env definedLocs' rhs
               let nloc = case loc of
                     Single _ -> getAliasLoc env loc
-                    SoA dcl fieldLocs ->
+                    SoA dcl fieldLocs' ->
                       let dcl' = getAliasLoc env (Single dcl)
-                          fieldLocs' = map (\(k, l) -> (k, getAliasLoc env l)) fieldLocs
-                       in SoA (unwrapLocVar dcl') fieldLocs'
+                          fieldLocs'' = map (\(k, l) -> (k, getAliasLoc env l)) fieldLocs'
+                       in SoA (unwrapLocVar dcl') fieldLocs''
                   ndconl = getAliasLoc env dconl
                   nfieldLocs = map (\(k, l) -> (k, getAliasLoc env l)) fieldLocs
               case existsLetForLoc of

--- a/gibbon-compiler/src/Gibbon/Passes/RegionsInwards.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/RegionsInwards.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wwarn #-}
 module Gibbon.Passes.RegionsInwards (regionsInwards) where
 
 import Data.Foldable as F

--- a/gibbon-compiler/src/Gibbon/Passes/RemoveCopies.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/RemoveCopies.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wwarn #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 -- | Replace calls to copy functions with tagged indirection nodes
 module Gibbon.Passes.RemoveCopies where
 
@@ -38,7 +38,6 @@ removeCopiesFn :: DDefs Ty2 -> FunDefs2 -> FunDef2 -> PassM FunDef2
 removeCopiesFn ddefs fundefs f@FunDef{funArgs,funTy,funBody} = do
   let initLocEnv = M.fromList $ map (\(LRM lc r _) -> case r of 
                                                           _ -> (lc, regionToVar r)
-                                                          SoAR _ _ -> error "TODO: removeCopiesFn structure of arrays not implemented yet."
                                     ) (locVars funTy)
       initTyEnv  = M.fromList $ zip funArgs (arrIns funTy)
       env2 = Env2 initTyEnv (initFunEnv fundefs)
@@ -78,10 +77,10 @@ removeCopiesExp ddefs fundefs lenv env2 ex =
         [] -> error $ "removeCopies: No indirection constructor found for: " ++ sdoc tycon
         [dcon] -> do
           let reg_lout = case (lenv # lout) of 
-                                  SingleR v -> v
+                                  SingleR v' -> v'
                                   SoARv _ _ -> error "removeCopies: structure of arrays not implemented yet."
           let reg_lin = case (lenv # lin) of 
-                                  SingleR v -> v
+                                  SingleR v' -> v'
                                   SoARv _ _ -> error "removeCopies: structure of arrays not implemented yet."
           LetE (v,locs,ty, Ext $ IndirectionE tycon dcon (lout , singleLocVar $ reg_lout) (lin, singleLocVar $ reg_lin) arg) <$>
             removeCopiesExp ddefs fundefs lenv (extendVEnv v ty env2) bod

--- a/gibbon-compiler/src/Gibbon/Passes/RemoveCopies.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/RemoveCopies.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wwarn #-}
 -- | Replace calls to copy functions with tagged indirection nodes
 module Gibbon.Passes.RemoveCopies where
 

--- a/gibbon-compiler/src/Gibbon/Passes/ReorderLetExprs.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/ReorderLetExprs.hs
@@ -1,9 +1,9 @@
-{-# OPTIONS_GHC -Wwarn #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
+{-# OPTIONS_GHC -Wno-unused-matches  #-}
 module Gibbon.Passes.ReorderLetExprs (reorderLetExprs) where
 
-import qualified Data.List as L 
 import qualified Data.Set as S
-
 import qualified Data.Map as M
 
 import Data.Foldable as F
@@ -12,7 +12,6 @@ import Text.PrettyPrint.GenericPretty
 import Gibbon.Common
 import Gibbon.L2.Syntax
 import Data.Maybe ()
-import qualified Data.Maybe as S
 
 data DelayedExpr = LetExpr (Var, [LocVar], Ty2, Exp2)
                  | LetLocExpr LocVar LocExp 
@@ -201,10 +200,6 @@ reorderLetExprsFunBody definedVars delayedExprMap ex = do
 
         FoldE _ _ _ -> error "reorderLetExprsFunBody: FoldE not supported!"
 
-        WithArenaE v e -> do
-            (e', delayedExprMap')  <- reorderLetExprsFunBody definedVars delayedExprMap e
-            pure $ (WithArenaE v e', delayedExprMap')
-
         Ext (LetLocE loc rhs bod) -> do
             let freeVarsRhs = freeVarsInLocExp rhs
                 --freeVarsRhs' = S.map (fromVarToFreeVarsTy) freeVarsRhs
@@ -293,7 +288,6 @@ reorderLetExprsFunBody definedVars delayedExprMap ex = do
             pure $ (Ext $ LetRegionE r sz ty bod', delayedExprMap')
         
         _ -> error $ "reorderLetExprs : unexpected expression not handled!!" ++ sdoc ex
-        _ -> pure (ex, delayedExprMap)
 
 
 {- We also need to release let expressions which are defined -}
@@ -445,7 +439,6 @@ releaseExprsFunBody definedVars delayedExprMap ex = do
             pure $ Ext $ LetRegionE r sz ty bod'
         
         _ -> error $ "reorderLetExprs : unexpected expression not handled!!" ++ sdoc ex
-        _ -> pure ex
         where
             releaseAllLetLocE :: DefinedVars -> DelayedExprMap -> [Exp2] -> PassM (DefinedVars, DelayedExprMap, [Exp2])
             releaseAllLetLocE envDefinedVars envDelayedExprMap letsToBeReleased = do
@@ -610,8 +603,7 @@ ensureLocationsAreDefinedForWrite definedVars ex = do
             pure $ Ext $ LetRegionE r sz ty bod'
         
         _ -> error $ "reorderLetExprs : unexpected expression not handled!!" ++ sdoc ex
-        _ -> pure ex
-    where 
+    where
         go = ensureLocationsAreDefinedForWrite definedVars
 
 

--- a/gibbon-compiler/src/Gibbon/Passes/ReorderLetExprs.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/ReorderLetExprs.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wwarn #-}
 module Gibbon.Passes.ReorderLetExprs (reorderLetExprs) where
 
 import qualified Data.List as L 

--- a/gibbon-compiler/src/Gibbon/Passes/ReorderScalarWrites.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/ReorderScalarWrites.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wwarn #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Gibbon.Passes.ReorderScalarWrites

--- a/gibbon-compiler/src/Gibbon/Passes/ReorderScalarWrites.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/ReorderScalarWrites.hs
@@ -1,4 +1,5 @@
-{-# OPTIONS_GHC -Wwarn #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Gibbon.Passes.ReorderScalarWrites
@@ -61,7 +62,7 @@ writeOrderMarkers (Prog ddefs fundefs mainExp) = do
                                                                             let aenvl = M.insert reg (RegionLocs [loc] S.empty) aenv
                                                                               in case loc of 
                                                                                     Single _ -> aenvl
-                                                                                    SoA dcloc fieldLocs -> 
+                                                                                    SoA _dcloc fieldLocs ->
                                                                                          let aenvl' = foldr (\(k, floc) acc -> do
                                                                                                                                let freg = case lookup k fieldRegs of 
                                                                                                                                              Just freg -> freg

--- a/gibbon-compiler/src/Gibbon/Passes/RouteEnds.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/RouteEnds.hs
@@ -1,5 +1,6 @@
-{-# OPTIONS_GHC -Wwarn #-}
-{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-unused-matches  #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-unused-binds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE RecordWildCards  #-}
@@ -36,13 +37,11 @@ import Data.Map as M
 import Data.Set as S
 import Control.Monad
 
-import Data.Foldable ( foldrM, foldlM )
+import Data.Foldable ( foldlM )
 
 import Gibbon.Common
 import Gibbon.L2.Syntax as L2
 import Gibbon.L1.Syntax as L1
-import Control.Arrow (Arrow(first))
-import Gibbon.L0.Typecheck (instDataConTy)
 import GHC.Generics
 import Text.PrettyPrint.GenericPretty
 
@@ -176,6 +175,8 @@ bindReturns ex =
         AllocateScalarsHere{} -> pure ex
         SSPush{} -> pure ex
         SSPop{} -> pure ex
+        LetRegE {} -> error "bindReturns: LetRegE not handled"
+        BoundsCheckVector {} -> error "bindReturns: BoundsCheckVector not handled"
     MapE{}  -> error $ "bindReturns: TODO MapE"
     FoldE{} -> error $ "bindReturns: TODO FoldE"
 
@@ -415,7 +416,7 @@ routeEnds prg@Prog{ddefs,fundefs,mainExp} = do
                                                                      in case self_recursive_locs_in_order of 
                                                                                   [] -> L.foldr f afterenv $ zip (L.map (fromLocVarToFreeVarsTy . snd) vls) (Sf.tailErr $ L.map snd vls)
                                                                                   _ -> let 
-                                                                                         first_self_rec = L.head self_recursive_locs_in_order  
+                                                                                         first_self_rec:_ = self_recursive_locs_in_order
                                                                                          (afterenv_self_rec', _) = L.foldl (\(acc, seen) tup@(v, l) -> if (l /= first_self_rec)
                                                                                                                                                        then
                                                                                                                                                          if seen == True
@@ -811,6 +812,7 @@ routeEnds prg@Prog{ddefs,fundefs,mainExp} = do
                                                                                                                                                                     let_to_release = case (M.lookup l1 inst_waiting_on_loc) of
                                                                                                                                                                                             Just lets -> let lets' = L.map (\exp -> case exp of 
                                                                                                                                                                                                                                           LetLocExpr a b -> LetLocE a b
+                                                                                                                                                                                                                                          LetExpr {} -> error "RouteEnds: unexpected LetExpr in inst_waiting_on_loc"
                                                                                                                                                                                                                           ) lets
                                                                                                                                                                                             
                                                                                                                                                                                                            in lets' ++ alias_same

--- a/gibbon-compiler/src/Gibbon/Passes/RouteEnds.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/RouteEnds.hs
@@ -1,7 +1,8 @@
+{-# OPTIONS_GHC -Wwarn #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE RecordWildCards  #-}
-{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
 -- | Insert end witnesses in an L2 program by changing function types,
 -- and updating expressions to pass (second-class) end locations around

--- a/gibbon-compiler/src/Gibbon/Passes/RouteEnds.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/RouteEnds.hs
@@ -384,9 +384,7 @@ routeEnds prg@Prog{ddefs,fundefs,mainExp} = do
                                   tyconOfDataCon = getTyOfDataCon ddefs dc
                                   argtys = lookupDataCon ddefs dc
                                   env2' = extendsVEnvLocVar (M.fromList (zip (L.map fromLocVarToFreeVarsTy locs) argtys ++ zip varsToFreeVarsTy argtys)) env2
-                                  lx = case M.lookup (fromVarToFreeVarsTy x) lenv of
-                                          Nothing -> error $ "Failed to find " ++ (show x)
-                                          Just l -> l
+                                  lx = scrutloc
                                   -- we know lx and need have the same end, since
                                   -- lx is the whole packed thing and need is its
                                   -- last field, so when we look up the end of lx

--- a/gibbon-compiler/src/Gibbon/Passes/ThreadRegions.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/ThreadRegions.hs
@@ -1,4 +1,5 @@
-{-# OPTIONS_GHC -Wwarn #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 module Gibbon.Passes.ThreadRegions where
 
 import qualified Data.List as L

--- a/gibbon-compiler/src/Gibbon/Passes/ThreadRegions.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/ThreadRegions.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wwarn #-}
 module Gibbon.Passes.ThreadRegions where
 
 import qualified Data.List as L

--- a/gibbon-compiler/src/Gibbon/Passes/ThreadRegions2.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/ThreadRegions2.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wwarn #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE BlockArguments #-}
 

--- a/gibbon-compiler/src/Gibbon/Passes/ThreadRegions2.hs
+++ b/gibbon-compiler/src/Gibbon/Passes/ThreadRegions2.hs
@@ -1,10 +1,11 @@
-{-# OPTIONS_GHC -Wwarn #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+{-# OPTIONS_GHC -Wno-unused-local-binds  #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE BlockArguments #-}
 
 module Gibbon.Passes.ThreadRegions2 where
 
-import Control.Monad.IO.Class (liftIO)
 import Data.Foldable (foldrM)
 import qualified Data.List as L
 import qualified Data.Map as M
@@ -17,7 +18,6 @@ import Gibbon.DynFlags
 import Gibbon.L2.Syntax as Old
 import Gibbon.NewL2.Syntax as NewL2
 import qualified Safe as Sf
-import System.IO (hPutStrLn, stderr)
 
 --------------------------------------------------------------------------------
 
@@ -168,7 +168,7 @@ threadRegionsFn ddefs fundefs f@FunDef {funName, funArgs, funTy, funMeta, funBod
                     packed_outs
                 regInsts =
                   concatMap
-                    ( \(LRM loc reg mode) ->
+                    ( \(LRM _loc reg mode) ->
                         case reg of
                           SoAR dcReg fieldRegs ->
                             let dcreg = regionToVar dcReg
@@ -895,7 +895,7 @@ threadRegionsExp ddefs fundefs fnLocArgs renv env2 lfenv rlocs_env wlocs_env pkd
       --                                        in acc'
       mp' <-
         mapM
-          ( \tup@(dcon, b, c) -> do
+          ( \tup@(dcon, b, _c) -> do
               let locs_case = dbgTrace (minChatLvl) "Print ty of Scrut: " dbgTrace (minChatLvl) (sdoc (reg)) dbgTrace (minChatLvl) "End scrut ty.\n" map (toLocVar . snd) b
               let region_locs' = case reg of
                     SingleR _ -> region_locs

--- a/gibbon-compiler/src/Gibbon/Pretty.hs
+++ b/gibbon-compiler/src/Gibbon/Pretty.hs
@@ -442,8 +442,8 @@ instance Pretty l => Pretty (L2.PreLocExp l) where
           --AfterVectorLE dexp fexps s -> lparen <> text "afterVectorOfLocs(" <+> pprint dexp <+> "," <+> (brackets $ hcat (punctuate "," (map pprint fexps))) <+> ")" <+> pprint s <> rparen
           AfterConstantLE i loc -> lparen <> pprint loc <+> text "+" <+> int i <> rparen
           AfterVariableLE v loc b -> if b
-				     then text "fresh" <> (parens $ pprint loc <+> text "+" <+> doc v)
-				     else parens $ pprint loc <+> text "+" <+> doc v
+            then text "fresh" <> (parens $ pprint loc <+> text "+" <+> doc v)
+            else parens $ pprint loc <+> text "+" <+> doc v
           InRegionLE r  -> lparen <> text "inRegion" <+> text (sdoc r) <> rparen
           FromEndLE loc -> lparen <> text "fromEnd" <+> pprint loc <> rparen
           AssignLE loc -> lparen <> text "assignLoc" <+> pprint loc <> rparen
@@ -455,7 +455,6 @@ instance Pretty l => Pretty (L2.PreRegExp l) where
         case re of
           L2.GetDataConRegSoA loc -> lparen <> text "getDataConRegSoA" <+> pprint loc <> rparen
           L2.GetFieldRegSoA (dcon, idx) loc -> lparen <> text "getFieldRegSoA" <+> lparen <> text dcon <+> "," <+> int idx <> rparen <+> pprint loc <> rparen
-		
 
 instance Pretty RegionSize where
     pprintWithStyle _ (BoundedSize x) = parens $ text "Bounded" <+> int x

--- a/gibbon-compiler/tests/L1/Typecheck.hs
+++ b/gibbon-compiler/tests/L1/Typecheck.hs
@@ -44,11 +44,14 @@ ddfs = M.fromList
           DDef {tyName = "Foo",
                 tyArgs = [],
                 dataCons = [("A", [(False, IntTy)]),
-                            ("B", [(False, IntTy),(False, IntTy)])]}),
+                            ("B", [(False, IntTy),(False, IntTy)])],
+                 memLayout = Linear}),
          ("Nat",
            DDef {tyName = "Nat",
                  tyArgs = [],
-                 dataCons = [("Zero", []),("Suc", [(False, PackedTy "Nat" ())])]})]
+                 dataCons = [("Zero", []),("Suc", [(False, PackedTy "Nat" ())])],
+                 memLayout = Linear})
+        ]
 
 l1TypecheckerTests :: TestTree
 l1TypecheckerTests = $(testGroupGenerator)


### PR DESCRIPTION
My guess is that `-Werror` has ben commented out before for local development but then accidentally committed to `main`. 

Initially, `-Werror ` was submitted here: https://github.com/gibbon-compiler/gibbon/pull/246. Although it got no reviews but it got a :heart: emoji from Chaitanya :-)

The reason I'm adding it back because I'm loading new code and getting loads or warnings that I think should not be there. `-Werror` would ensure that.